### PR TITLE
Adds QuantizeMultiple, which produces a palette for a slice of images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/carbocation/go-quantize
 
-go 1.12
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ericpauley/go-quantize
+module github.com/carbocation/go-quantize
 
 go 1.12

--- a/quantize/bench/go.mod
+++ b/quantize/bench/go.mod
@@ -1,11 +1,11 @@
-module github.com/ericpauley/go-quantize/quantize/bench
+module github.com/carbocation/go-quantize/quantize/bench
 // Note: We use a separate go.mod file here because comparison libraries should not be in top-level dependencies
 go 1.12
 
 require (
-	github.com/ericpauley/go-quantize v0.0.0-20180803033130-bfdbba883ede
+	github.com/carbocation/go-quantize v0.0.0-20180803033130-bfdbba883ede
 	github.com/esimov/colorquant v1.0.0
 	github.com/soniakeys/quant v1.0.0
 )
 
-replace github.com/ericpauley/go-quantize => ../..
+replace github.com/carbocation/go-quantize => ../..

--- a/quantize/mediancut.go
+++ b/quantize/mediancut.go
@@ -5,6 +5,7 @@ package quantize
 import (
 	"image"
 	"image/color"
+	"math"
 	"sync"
 )
 
@@ -151,13 +152,36 @@ func (q MedianCutQuantizer) buildBucketMultiple(ms []image.Image) (bucket colorB
 		return colorBucket{}
 	}
 
-	bounds := ms[0].Bounds()
-	size := (bounds.Max.X - bounds.Min.X) * (bounds.Max.Y - bounds.Min.Y) * 2
+	// If all images are not the same size, and if the first image is not the
+	// largest on both X and Y dimensions, this function will eventually trigger
+	// a panic unless we've configured the bounds to be based on the greatest x
+	// and y of all images in the gif, which we do here:
+	leastX, greatestX, leastY, greatestY := math.MaxInt32, 0, math.MaxInt32, 0
+	for _, palettedImage := range ms {
+		if palettedImage.Bounds().Min.X < leastX {
+			leastX = palettedImage.Bounds().Min.X
+		}
+		if palettedImage.Bounds().Max.X > greatestX {
+			greatestX = palettedImage.Bounds().Max.X
+		}
+
+		if palettedImage.Bounds().Min.Y < leastY {
+			leastY = palettedImage.Bounds().Min.Y
+		}
+		if palettedImage.Bounds().Max.Y > greatestY {
+			greatestY = palettedImage.Bounds().Max.Y
+		}
+	}
+
+	size := (greatestX - leastX) * (greatestY - leastY) * 2
 	sparseBucket := bpool.getBucket(size)
 
 	for _, m := range ms {
-		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+		// Since images may have variable size, don't go beyond each specific
+		// image's X and Y bounds while we iterate, rather than using the global
+		// min and max x and y
+		for y := m.Bounds().Min.Y; y < m.Bounds().Max.Y; y++ {
+			for x := m.Bounds().Min.X; x < m.Bounds().Max.X; x++ {
 				priority := uint32(1)
 				if q.Weighting != nil {
 					priority = q.Weighting(m, x, y)

--- a/quantize/mediancut.go
+++ b/quantize/mediancut.go
@@ -122,6 +122,9 @@ func (q MedianCutQuantizer) quantizeSlice(p color.Palette, colors []colorPriorit
 	p = q.palettize(p, buckets)
 	if addTransparent {
 		p = append(p, color.RGBA{0, 0, 0, 0})
+
+		// Set our transparent color to be the first color
+		p[0], p[len(p)-1] = p[len(p)-1], p[0]
 	}
 	return p
 }

--- a/quantize/mediancut_test.go
+++ b/quantize/mediancut_test.go
@@ -24,7 +24,7 @@ func TestBuildBucket(t *testing.T) {
 
 	q := MedianCutQuantizer{Mode, nil, false}
 
-	colors := q.buildBucket(i)
+	colors := q.buildBucketMultiple([]image.Image{i})
 	t.Logf("Naive color map contains %d elements", len(colors))
 
 	for _, p := range colors {
@@ -40,7 +40,7 @@ func TestBuildBucket(t *testing.T) {
 		return 0
 	}, false}
 
-	colors = q.buildBucket(i)
+	colors = q.buildBucketMultiple([]image.Image{i})
 	t.Logf("Color map contains %d elements", len(colors))
 }
 


### PR DESCRIPTION
As noted in #1 , for animated gifs, it is ideal to build a palette that is aware of all of the images that will contribute to the gif. This pull request adds `QuantizeMultiple`, which ingests a slice of images rather than a single image. This preserves `Quantize` in order to prevent breaking the public API. It modifies the private API by changing `buildBucketMultiple` to `buildBucket` and causing it to ingest a slice of images rather than just one. 

Visually/subjectively, this produces nicer appearing images for me than (a) applying Quantize either to every image separately, which can lead to palette jitter between frames, or (b) applying Quantize to just one key image and applying the palette to every image, which can lead to inappropriate coloration in some frames.